### PR TITLE
Support for setting record TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Configuration is accomplished through the use of environment variables. The incl
 | `GANDI_PAT`       | -                                   | Personal Access Token for your [Gandi.net account](https://docs.gandi.net/en/managing_an_organization/organizations/personal_access_token.html) |
 | `GANDI_DOMAIN`    | -                                   | Your Gandi.net domain name                                                                                                                      |
 | `GANDI_RECORD`    | `@`                                 | Record to update with your IP address                                                                                                           |
+| `GANDI_TTL`       | -                                   | TTL in seconds for the updated records                                                                                                          |
 | `UPDATE_SCHEDULE` | `*/5 * * * *`                       | Cron-style schedule for dynamic-dns updates.                                                                                                    |
 
 ## License

--- a/app/gandi-ddns.py
+++ b/app/gandi-ddns.py
@@ -152,6 +152,8 @@ def update_a_record() -> None:
     elif changed:
         try:
             payload = {"rrset_values": ["{}".format(ip)]}
+            if GANDI_TTL:
+                payload["rrset_ttl"] = str(GANDI_TTL)
             response = requests.put(
                 f"{GANDI_URL}domains/{GANDI_DOMAIN}/records/{GANDI_RECORD}/A",
                 json=payload,
@@ -179,6 +181,8 @@ def update_aaaa_record() -> None:
     elif changed:
         try:
             payload = {"rrset_values": ["{}".format(ip)]}
+            if GANDI_TTL:
+                payload["rrset_ttl"] = str(GANDI_TTL)
             response = requests.put(
                 f"{GANDI_URL}domains/{GANDI_DOMAIN}/records/{GANDI_RECORD}/AAAA",
                 json=payload,
@@ -199,6 +203,7 @@ if __name__ == "__main__":
     GANDI_PAT = _get_env_var("GANDI_PAT")
     GANDI_DOMAIN = _get_env_var("GANDI_DOMAIN", required=True)
     GANDI_RECORD = _get_env_var("GANDI_RECORD", "@")
+    GANDI_TTL = _get_env_var("GANDI_TTL")
 
     # Deprecation checks
     if GANDI_KEY and GANDI_PAT:


### PR DESCRIPTION
Introduce a GANDI_TTL environment variable which, when set, determines the TTL of the updated DNS records.

The variable currently has no default, so default behaviour is unchanged.