### PR TITLE
fix: f-string missing in update_aaaa_record and update Gandi API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,15 @@ Configuration is accomplished through the use of environment variables. The incl
 
 #### Environment Variables
 
-| Variable          | Default                             | Description                                                                                                                                     |
-| ----------------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GANDI_URL`       | `https://dns.api.gandi.net/api/v5/` | URL of the Gandi API.                                                                                                                           |
-| `GANDI_KEY`       | -                                   | _DEPRECATED_ API Key for your [Gandi.net account](https://docs.gandi.net/en/domain_names/advanced_users/api.html)                               |
-| `GANDI_PAT`       | -                                   | Personal Access Token for your [Gandi.net account](https://docs.gandi.net/en/managing_an_organization/organizations/personal_access_token.html) |
-| `GANDI_DOMAIN`    | -                                   | Your Gandi.net domain name                                                                                                                      |
-| `GANDI_RECORD`    | `@`                                 | Record to update with your IP address                                                                                                           |
-| `GANDI_TTL`       | -                                   | TTL in seconds for the updated records                                                                                                          |
-| `UPDATE_SCHEDULE` | `*/5 * * * *`                       | Cron-style schedule for dynamic-dns updates.                                                                                                    |
+| Variable          | Default                            | Description                                                                                                                                     |
+| ----------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GANDI_URL`       | `https://api.gandi.net/v5/` | URL of the Gandi API.                                                                                                                           |
+| `GANDI_KEY`       | -                                  | _DEPRECATED_ API Key for your [Gandi.net account](https://docs.gandi.net/en/domain_names/advanced_users/api.html)                               |
+| `GANDI_PAT`       | -                                  | Personal Access Token for your [Gandi.net account](https://docs.gandi.net/en/managing_an_organization/organizations/personal_access_token.html) |
+| `GANDI_DOMAIN`    | -                                  | Your Gandi.net domain name                                                                                                                      |
+| `GANDI_RECORD`    | `@`                                | Record to update with your IP address                                                                                                           |
+| `GANDI_TTL`       | -                                  | TTL in seconds for the updated records                                                                                                          |
+| `UPDATE_SCHEDULE` | `*/5 * * * *`                      | Cron-style schedule for dynamic-dns updates.                                                                                                    |
 
 ## License
 

--- a/app/gandi-ddns.py
+++ b/app/gandi-ddns.py
@@ -163,7 +163,7 @@ def update_a_record() -> None:
             if GANDI_TTL:
                 payload["rrset_ttl"] = int(GANDI_TTL)
             response = requests.put(
-                f"{GANDI_URL}domains/{GANDI_DOMAIN}/records/{GANDI_RECORD}/A",
+                f"{GANDI_URL}livedns/domains/{GANDI_DOMAIN}/records/{GANDI_RECORD}/A",
                 json=payload,
                 headers=_get_headers(),
             )
@@ -192,7 +192,7 @@ def update_aaaa_record() -> None:
             if GANDI_TTL:
                 payload["rrset_ttl"] = int(GANDI_TTL)
             response = requests.put(
-                f"{GANDI_URL}domains/{GANDI_DOMAIN}/records/{GANDI_RECORD}/AAAA",
+                f"{GANDI_URL}livedns/domains/{GANDI_DOMAIN}/records/{GANDI_RECORD}/AAAA",
                 json=payload,
                 headers=_get_headers(),
             )
@@ -202,11 +202,11 @@ def update_aaaa_record() -> None:
         else:
             print(f"Set IP to {ip} for AAAA record '{GANDI_RECORD}' for {GANDI_DOMAIN}")
     else:
-        print("No change in external IP ({ip}), not updating AAAA record")
+        print(f"No change in external IP ({ip}), not updating AAAA record")
 
 
 if __name__ == "__main__":
-    GANDI_URL = _get_env_var("GANDI_URL", "https://dns.api.gandi.net/api/v5/")
+    GANDI_URL = _get_env_var("GANDI_URL", "https://api.gandi.net/v5/")
     GANDI_KEY = _get_env_var("GANDI_KEY")
     GANDI_PAT = _get_env_var("GANDI_PAT")
     GANDI_DOMAIN = _get_env_var("GANDI_DOMAIN", required=True)


### PR DESCRIPTION
## Changes

- Fixed missing f-string in `update_aaaa_record()` causing `{ip}` to be printed literally instead of the actual IP address
- Updated Gandi LiveDNS API URL to the current endpoint (previous URL was deprecated but still functional)