### PR TITLE
feat: add Shoutrrr notifications on IP change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,15 @@
+# ── Stage 1 : récupération du binaire Shoutrrr ──────────────────────────────
+FROM alpine:3.21 AS shoutrrr-fetcher
+
+ARG SHOUTRRR_VERSION=0.8.0
+
+RUN apk add --no-cache curl \
+ && curl -fsSL \
+    "https://github.com/containrrr/shoutrrr/releases/download/v${SHOUTRRR_VERSION}/shoutrrr_linux_amd64" \
+    -o /usr/local/bin/shoutrrr \
+ && chmod +x /usr/local/bin/shoutrrr
+
+# ── Stage 2 : image finale ───────────────────────────────────────────────────
 FROM python:3.14-alpine
 
 LABEL org.opencontainers.image.title="Gandi DDNS"
@@ -5,6 +17,8 @@ LABEL org.opencontainers.image.description="Dynamic DNS Update Client for Gandi'
 LABEL org.opencontainers.image.authors="Winston Astrachan"
 LABEL org.opencontainers.image.source="https://github.com/wastrachan/docker-gandi-ddns/"
 LABEL org.opencontainers.image.licenses="MIT"
+
+COPY --from=shoutrrr-fetcher /usr/local/bin/shoutrrr /usr/local/bin/shoutrrr
 
 COPY app/ /
 RUN set -eux; \

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Run this image with the `make run` shortcut, or manually with `docker run`. You'
 ```shell
 docker run --name gandi-ddns \
            --rm \
-           -e GANDI_KEY="12343123abcd" \
+           -e GANDI_PAT="12343123abcd" \
            -e GANDI_DOMAIN="mydomain.net" \
            wastrachan/gandi-ddns:latest
 ```
@@ -53,15 +53,48 @@ Configuration is accomplished through the use of environment variables. The incl
 
 #### Environment Variables
 
-| Variable          | Default                            | Description                                                                                                                                     |
-| ----------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Variable          | Default                     | Description                                                                                                                                     |
+| ----------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `GANDI_URL`       | `https://api.gandi.net/v5/` | URL of the Gandi API.                                                                                                                           |
-| `GANDI_KEY`       | -                                  | _DEPRECATED_ API Key for your [Gandi.net account](https://docs.gandi.net/en/domain_names/advanced_users/api.html)                               |
-| `GANDI_PAT`       | -                                  | Personal Access Token for your [Gandi.net account](https://docs.gandi.net/en/managing_an_organization/organizations/personal_access_token.html) |
-| `GANDI_DOMAIN`    | -                                  | Your Gandi.net domain name                                                                                                                      |
-| `GANDI_RECORD`    | `@`                                | Record to update with your IP address                                                                                                           |
-| `GANDI_TTL`       | -                                  | TTL in seconds for the updated records                                                                                                          |
-| `UPDATE_SCHEDULE` | `*/5 * * * *`                      | Cron-style schedule for dynamic-dns updates.                                                                                                    |
+| `GANDI_KEY`       | -                           | _DEPRECATED_ API Key for your [Gandi.net account](https://docs.gandi.net/en/domain_names/advanced_users/api.html)                               |
+| `GANDI_PAT`       | -                           | Personal Access Token for your [Gandi.net account](https://docs.gandi.net/en/managing_an_organization/organizations/personal_access_token.html) |
+| `GANDI_DOMAIN`    | -                           | Your Gandi.net domain name                                                                                                                      |
+| `GANDI_RECORD`    | `@`                         | Record to update with your IP address                                                                                                           |
+| `GANDI_TTL`       | -                           | TTL in seconds for the updated records                                                                                                          |
+| `UPDATE_SCHEDULE` | `*/5 * * * *`               | Cron-style schedule for dynamic-dns updates.                                                                                                    |
+| `SHOUTRRR_URL`    | -                           | Optional [Shoutrrr](https://containrrr.dev/shoutrrr/services/overview) notification URL. If set, a notification is sent on every DNS update.   |
+
+## Notifications
+
+This image supports push notifications via [Shoutrrr](https://containrrr.dev/shoutrrr) when a DNS record is updated. Set the `SHOUTRRR_URL` environment variable with the URL of your desired provider:
+
+```shell
+# ntfy
+docker run --name gandi-ddns \
+           --rm \
+           -e GANDI_PAT="12343123abcd" \
+           -e GANDI_DOMAIN="mydomain.net" \
+           -e SHOUTRRR_URL="ntfy://ntfy.sh/my-topic" \
+           wastrachan/gandi-ddns:latest
+
+# Telegram
+docker run --name gandi-ddns \
+           --rm \
+           -e GANDI_PAT="12343123abcd" \
+           -e GANDI_DOMAIN="mydomain.net" \
+           -e SHOUTRRR_URL="telegram://BOT_TOKEN@telegram?chats=CHAT_ID" \
+           wastrachan/gandi-ddns:latest
+
+# Discord
+docker run --name gandi-ddns \
+           --rm \
+           -e GANDI_PAT="12343123abcd" \
+           -e GANDI_DOMAIN="mydomain.net" \
+           -e SHOUTRRR_URL="discord://TOKEN@WEBHOOK_ID" \
+           wastrachan/gandi-ddns:latest
+```
+
+For the full list of supported providers and URL formats, see the [Shoutrrr documentation](https://containrrr.dev/shoutrrr/services/overview).
 
 ## License
 

--- a/app/gandi-ddns.py
+++ b/app/gandi-ddns.py
@@ -8,6 +8,7 @@ Released under the terms of the MIT license
 """
 
 import os
+import subprocess
 from typing import Dict, List, Optional, Tuple, TypedDict
 
 import requests
@@ -97,6 +98,34 @@ def _get_headers() -> Dict[str, str]:
     return headers
 
 
+def notify(message: str) -> None:
+    """Send a notification via Shoutrrr.
+
+    Sends a notification message using the Shoutrrr CLI if SHOUTRRR_URL is set.
+    Silently skips if SHOUTRRR_URL is not configured.
+
+    Args:
+        message: The notification message to send.
+    """
+    if not SHOUTRRR_URL:
+        return
+    try:
+        result = subprocess.run(
+            ["shoutrrr", "send", "--url", SHOUTRRR_URL, "--message", message],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            print(f"Shoutrrr notification failed: {result.stderr.strip()}")
+    except FileNotFoundError:
+        print("Shoutrrr binary not found. Skipping notification.")
+    except subprocess.TimeoutExpired:
+        print("Shoutrrr notification timed out.")
+    except Exception as e:
+        print(f"Shoutrrr notification error: {e}")
+
+
 def get_ipv4() -> Tuple[Optional[str], bool]:
     """Get the current public IPv4 address and check if it has changed.
 
@@ -152,7 +181,7 @@ def update_a_record() -> None:
 
     Checks the current public IPv4 address and updates the corresponding A record
     in Gandi's DNS service if a change is detected. Prints status messages to
-    indicate the result of the operation.
+    indicate the result of the operation. Sends a Shoutrrr notification on success.
     """
     ip, changed = get_ipv4()
     if not ip:
@@ -171,7 +200,9 @@ def update_a_record() -> None:
         except Exception as e:
             print(f"Unable to update DNS record: {e}")
         else:
-            print(f"Set IP to {ip} for A record '{GANDI_RECORD}' for {GANDI_DOMAIN}")
+            msg = f"DDNS updated: A record '{GANDI_RECORD}' for {GANDI_DOMAIN} set to {ip}"
+            print(msg)
+            notify(msg)
     else:
         print(f"No change in external IP ({ip}), not updating A record")
 
@@ -181,7 +212,7 @@ def update_aaaa_record() -> None:
 
     Checks the current public IPv6 address and updates the corresponding AAAA record
     in Gandi's DNS service if a change is detected. Prints status messages to
-    indicate the result of the operation.
+    indicate the result of the operation. Sends a Shoutrrr notification on success.
     """
     ip, changed = get_ipv6()
     if not ip:
@@ -200,7 +231,9 @@ def update_aaaa_record() -> None:
         except Exception as e:
             print(f"Unable to update DNS record: {e}")
         else:
-            print(f"Set IP to {ip} for AAAA record '{GANDI_RECORD}' for {GANDI_DOMAIN}")
+            msg = f"DDNS updated: AAAA record '{GANDI_RECORD}' for {GANDI_DOMAIN} set to {ip}"
+            print(msg)
+            notify(msg)
     else:
         print(f"No change in external IP ({ip}), not updating AAAA record")
 
@@ -212,6 +245,7 @@ if __name__ == "__main__":
     GANDI_DOMAIN = _get_env_var("GANDI_DOMAIN", required=True)
     GANDI_RECORD = _get_env_var("GANDI_RECORD", "@")
     GANDI_TTL = _get_env_var("GANDI_TTL")
+    SHOUTRRR_URL = _get_env_var("SHOUTRRR_URL")
 
     # Deprecation checks
     if GANDI_KEY and GANDI_PAT:

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,17 @@
 {
-  "extends": ["config:base"]
+  "extends": ["config:base"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "Dockerfile"
+      ],
+      "matchStrings": [
+        "ARG SHOUTRRR_VERSION=(?<currentValue>[\\d.]+)"
+      ],
+      "depNameTemplate": "containrrr/shoutrrr",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    }
+  ]
 }


### PR DESCRIPTION
## feat: add Shoutrrr notifications on IP change

### Description

Integrates [Shoutrrr](https://github.com/containrrr/shoutrrr) to send a notification whenever a DNS A or AAAA record is successfully updated.

### Changes

**`app/gandi-ddns.py`**
- Added `notify()` function using `subprocess` (Python standard library, no additional dependency)
- `notify()` is called in `update_a_record()` and `update_aaaa_record()` after a successful update
- New optional environment variable `SHOUTRRR_URL` — if not set, notifications are silently skipped

**`Dockerfile`**
- Added a `shoutrrr-fetcher` stage (multi-stage build) to download the Shoutrrr binary from GitHub Releases
- Version pinned via `ARG SHOUTRRR_VERSION=0.8.0`
- Binary copied into the final image via `COPY --from=shoutrrr-fetcher`

**`renovate.json`**
- Added a regex `customManagers` entry to track `ARG SHOUTRRR_VERSION` in the Dockerfile and automatically open PRs when new Shoutrrr releases are published

### Usage

Pass the `SHOUTRRR_URL` variable to the container with the desired provider URL:

```bash
# ntfy
-e SHOUTRRR_URL="ntfy://ntfy.sh/my-topic"

# Telegram
-e SHOUTRRR_URL="telegram://BOT_TOKEN@telegram?chats=CHAT_ID"

# Discord
-e SHOUTRRR_URL="discord://TOKEN@WEBHOOK_ID"
```

Full list of supported providers: https://containrrr.dev/shoutrrr/services/overview

### Notes
- No changes to `requirements.txt` (Shoutrrr is a standalone Go binary, `subprocess` is native Python)
- No changes to the CircleCI pipeline